### PR TITLE
Fix "config timezone" command 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-rotation",
-  "version": "0.3.11.alpha.1",
+  "version": "0.4.0.alpha",
   "author": "Otsuki Hitoshi <hitochan777@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -83,7 +83,7 @@ export default (robot: hubot.Robot) => {
   robot.hear(buildCommand("delete (.+)"), handler.deleteUser.bind(handler))
   robot.hear(buildCommand("show"), handler.showUsers.bind(handler))
   robot.hear(
-    buildCommand("config timezone( (.+))?"),
+    buildCommand("config timezone( (\\S+))?"),
     handler.configTimezone.bind(handler)
   )
 }


### PR DESCRIPTION
- Fix bug of `config timezone <UTC offset>` not working when there are trailing spaces.