### PR TITLE
Fix invalid version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-rotation",
-  "version": "0.4.0.alpha",
+  "version": "0.4.0",
   "author": "Otsuki Hitoshi <hitochan777@gmail.com>",
   "license": "MIT",
   "main": "dist/index.js",


### PR DESCRIPTION
It seems that npm no longer accepts this type of version notation `0.3.0.alpha.1`.
So I changed it to `MAJOR.MINOR.PATCH`